### PR TITLE
Custom shutdown message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@
 
 * `InitNode` is now blocking. This means that on startup up a node, it will only unblock once the cluster is properly bootstrapped, that is if the expected number of nodes have formed a cluster.
 
-### Features
+### General Changes
 
+* Bump memberlist to `v0.2.2`
 * Raftify is now able to distinguish between intended and crash- or timeout-related leave events. This allows it to immediately adjust the quorum for intended leave events instead of having to wait for the dead nodes to be kicked out of the cluster.
+
+### Bugfixes
+
+* Fixed a bug that prevented nodes with `expect = 1` from becoming the cluster leader if there were other peers listed in the peerlist of the raftify.json file.
 
 ## v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+## Unreleased
+
+### Breaking Changes
+
+* `InitNode` is now blocking. This means that on startup up a node, it will only unblock once the cluster is properly bootstrapped, that is if the expected number of nodes have formed a cluster.
+
+### Features
+
+* Raftify is now able to distinguish between intended and crash- or timeout-related leave events. This allows it to immediately adjust the quorum for intended leave events instead of having to wait for the dead nodes to be kicked out of the cluster.
+
+## v0.1.0
+
+* First release

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > :warning: This project has not yet had a security audit or stress test and is therefore not ready for use in production! Use at your own risk!
 
-_Raftify_ is a Go implementation of the Raft leader election algorithm without the Raft log and enables the creation of a self-managing cluster of nodes by transforming an application into a Raft node. It is meant to be a **more cost-efficient** and **better-scaling** alternative to running a full-fledged Raft cluster with separate clients in an active/active setup.
+_Raftify_ is a Go implementation of the Raft leader election algorithm without the Raft log and enables the creation of a self-managing cluster of nodes by transforming an application into a Raft node. It is meant to be a **more cost-efficient** small-scale alternative to running an active/active validator cluster with a separate full-fledged Raft consensus layer.
 
 It is designed to be directly embedded into an application and provide a direct way of communicating between individual nodes, omitting the overhead caused by replicating a log.
 Raftify was built with one particular use case in mind: **running a self-managing cluster of Cosmos validators**.
@@ -18,18 +18,20 @@ Raftify was built with one particular use case in mind: **running a self-managin
 
 ## Configuration Reference
 
-The configuration is to be provided in a `raftify.json` file. It needs to be put into the working directory specified in the second parameter of the `InitNode` method. For Gaia, this would be `~/.gaiad/config/`.
+The configuration is to be provided in a `raftify.json` file and must be located in the working directory specified in the second parameter of the `InitNode` method.
+
+> :information_source: For Gaia, the working directory is `~/.gaiad/config/` by default.
 
 | Key         | Value    | Description                                                                                                                                                                                                           |
 |:------------|:---------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `id`          | string   | **(Mandatory)** The node's identifier.</br>Must be **unique**.                                                                                                                                                         |
-| `max_nodes`   | int      | **(Mandatory)** The self-imposed limit of nodes to be run in the cluster.</br>Must be greater than 0. |
+| `max_nodes`   | int      | **(Mandatory)** The self-imposed limit of nodes to be run in the cluster.</br>Must be greater than 0 and must never be exceeded. |
 | `expect`      | int      | **(Mandatory)** The number of nodes expected to be online in order to bootstrap the cluster and start the leader election. Once the expected number of nodes is online, all cluster members will be started simultaneously.</br>Must be 1 or higher.</br>:warning: Please use `expect = 1` for single-node setups only. If you plan on running more than one node, set the `expect` value to the final cluster size on **ALL** nodes. |
-| `encrypt`     | string   | _(Optional)_ The hex representation of the secret key used to encrypt messages.</br>The value must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.</br>Use [this tool](https://www.browserling.com/tools/random-bytes) to generate a key. |
+| `encrypt`     | string   | _(Optional)_ The hex representation of the secret key used to encrypt messages.</br>The value must be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256.</br>[**Use this tool to generate a key.**](https://www.browserling.com/tools/random-bytes) |
 | `performance` | int      | _(Optional)_ The modifier used to multiply the maximum and minimum timeout and ticker settings. Higher values increase leader stability and reduce bandwidth and CPU but also increase the time needed to recover from a leader failure.</br>Must be 1 or higher. Defaults to 1 which is also the maximum performance setting. |
 | `log_level`   | string   | _(Optional)_ The minimum log level for console log messages.</br>Can be DEBUG, INFO, WARN, ERR. Defaults to `WARN`.                                                                                                    |
-| `bind_addr`   | string   | _(Optional)_ The address to bind to.</br>Defaults to `0.0.0.0`.                                                                                                                                                        |
-| `bind_port`   | string   | _(Optional)_ The port to bind to.</br>Defaults to `7946`.                                                                                                                                                              |
+| `bind_addr`   | string   | _(Optional)_ The address to bind the node application to.</br>Defaults to `0.0.0.0`.                                                                                                                                                        |
+| `bind_port`   | string   | _(Optional)_ The port to bind the node application to.</br>Defaults to `7946`.                                                                                                                                                              |
 | `peer_list`   | []string | _(Optional)_ The list of IP addresses of all cluster members (optionally including the address of the local node). It is used to determine the quorum in a non-bootstrapped cluster.</br>For example, if your peerlist has `n = 3` nodes then `math.Floor((n/2)+1) = 2` nodes will need to be up and running to bootstrap the cluster.</br>Addresses must be provided in the `host:port` format.</br>Must not be empty if more than one node is expected. |
 
 ### Example Configuration
@@ -78,6 +80,6 @@ Use
 make tests
 ```
 
-to run package unit and integration tests.
+to run unit and integration tests.
 
 > :information_source: Code coverage may vary due to the nature of the Raft consensus algorithm as well as fluctuations in network connectivity.

--- a/bootstrap.go
+++ b/bootstrap.go
@@ -37,7 +37,12 @@ func (n *Node) toBootstrap() {
 		if len(n.config.PeerList) == 0 {
 			n.toLeader()
 		} else {
+			n.logger.Printf("[INFO] raftify: Expect is set to 1, but found %v peers. Going through full consensus cycle...", len(n.config.PeerList))
 			n.toFollower(0)
+
+			if err := n.tryJoin(); err != nil {
+				n.logger.Printf("[ERR] raftify: failed to join cluster: %v\nTrying again...\n", err.Error())
+			}
 		}
 
 		n.printMemberlist()

--- a/config.go
+++ b/config.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/hashicorp/memberlist"
 
@@ -158,7 +159,7 @@ func (c *Config) validate() error {
 	}
 
 	if errs != "" {
-		return fmt.Errorf("found errors in raftify.json:\n%v", errs)
+		return fmt.Errorf("found errors in raftify.json:\n%v", strings.TrimSuffix(errs, "\n"))
 	}
 	return nil
 }

--- a/doc/raftify.adoc
+++ b/doc/raftify.adoc
@@ -57,6 +57,7 @@ Must be 1 or higher.
 |encrypt|string|_(Optional)_ The hex representation of the secret key used to encrypt messages.
 The value must be either 16, 24 or 32 bytes to select AES-128, AES-192 or AES-256.
 https://www.browserling.com/tools/random-bytes[*Use this tool to generate a key*].
+*IMPORTANT:* Strongly recommended for use in production.
 
 |performance|int|_(Optional)_ The modifier used to multiply the maximum and minimum timeout and ticker settings. Higher values increase leader stability and reduce bandwidth and CPU but also increase the time needed to recover from a leader failure.
 Must be 1 or higher. Defaults to 1 which is also the maximum performance setting.

--- a/doc/raftify.adoc
+++ b/doc/raftify.adoc
@@ -32,7 +32,7 @@ During an election, each node can only vote for one candidate. A candidate alway
 
 * A cluster size of n can tolerate up to `floor((n-1)/2)`` node failures.
 ** Example: A cluster of 5 nodes tolerates `floor((5-1)/2) = 2` node failures.
-* There must never fail more than `floor((n-1)/2)`_` nodes at the same time. Once the failed nodes are kicked out of the memberlist and the size shrinks, the tolerance resets to the new reduced cluster size.
+* There must never fail more than `floor((n-1)/2)` nodes at the same time. Once the failed nodes are kicked out of the memberlist and the size shrinks, the tolerance resets to the new reduced cluster size.
 ** Example 1: If in a cluster of 5 nodes 3 nodes fail in a short time frame, the remaining 2 nodes will never be able to reach the quorum again in order to negotiate a new leader.
 ** Example 2: If in a cluster of 5 nodes 2 nodes fail in a short time frame, the remaining 3 nodes will still be able to reach the quorum in order to negotiate a new leader. The crashed nodes will eventually be kicked from the memberlist, thus shrinking the cluster size to a total of 3 nodes and adjusting its failure tolerance to `floor((3-1)/2) = 1` node.
 
@@ -55,7 +55,8 @@ Must be 1 or higher.
 *WARNING:* Please use `expect = 1` for single-node setups only. If you plan on running more than one node, set the `expect` value to the final cluster size on **ALL** nodes. 
 
 |encrypt|string|_(Optional)_ The hex representation of the secret key used to encrypt messages.
-The value must be either 16, 24 or 32 bytes to select AES-128, AES-192 or AES-256. Use https://www.browserling.com/tools/random-bytes[this tool] to generate a key.
+The value must be either 16, 24 or 32 bytes to select AES-128, AES-192 or AES-256.
+https://www.browserling.com/tools/random-bytes[*Use this tool to generate a key*].
 
 |performance|int|_(Optional)_ The modifier used to multiply the maximum and minimum timeout and ticker settings. Higher values increase leader stability and reduce bandwidth and CPU but also increase the time needed to recover from a leader failure.
 Must be 1 or higher. Defaults to 1 which is also the maximum performance setting.
@@ -104,7 +105,7 @@ are better, and 0 means "totally healthy".
 func (n *Node) GetMembers() map[string]string
 ----
 
-Returns a map of all members listed in the local memberlist with their respective id and address.
+Returns a map of all members listed in the local memberlist with their respective `id` and `address`.
 
 [source,go]
 ----

--- a/doc/raftify.adoc
+++ b/doc/raftify.adoc
@@ -112,14 +112,3 @@ func (n *Node) GetState() State
 ----
 
 Returns the node's current state which is either Leader, Follower, PreCandidate or Candidate.
-
-== Optional Features/Improvements
-
-[cold="3*"]
-|===
-|Current state|Proposed changes|Desired effect
-
-|Intended and unintended leave events are internally handled the same. There’s no difference between a node being shut down and a crashed node leaving the cluster.|Implement custom message to be broadcasted alongside the default events that triggers an immediate change of the cluster size for intended leave events and therefore also the quorum.|Makes sure that only failover scenarios are backed by the constraint of having to reach the quorum of the previous cluster size. A cluster with 2 nodes for example could be shrunk to a single-node cluster and keep running despite the majority of nodes taken offline.
-
-|Once the expected number of nodes are online and the cluster is bootstrapped, the nodes go through the full election process in order to elect their first leader.|Make the first node to start up the first leader on successful bootstrap. This can be measured by how many peers could be reached. If a node reaches no peers, it means that it started up first and thus it will skip the precandidate and candidate states and immediately become the first leader.|This skips the delay associated with the prevoting and voting phase needed to elect the first leader in order to get things going. This saves a few seconds on startup at best, so it’s nice to have.
-|===

--- a/follower.go
+++ b/follower.go
@@ -2,6 +2,9 @@ package raftify
 
 import (
 	"encoding/json"
+	"math"
+
+	"github.com/hashicorp/memberlist"
 )
 
 // toFollower initiates the transition into a follower node for a given term. Calling toFollower
@@ -52,6 +55,14 @@ func (n *Node) runFollower() {
 			}
 			n.handleVoteRequest(content)
 
+		case NewQuorumMsg:
+			var content NewQuorum
+			if err := json.Unmarshal(msg.Content, &content); err != nil {
+				n.logger.Printf("[ERR] raftify: error while unmarshaling new quorum message: %v\n", err.Error())
+				break
+			}
+			n.handleNewQuorum(content)
+
 		default:
 			n.logger.Printf("[WARN] raftify: received %v as follower, discarding...\n", msg.Type.toString())
 		}
@@ -75,8 +86,14 @@ func (n *Node) runFollower() {
 		}
 		n.toPreCandidate()
 
-	case <-n.events.eventCh:
+	case event := <-n.events.eventCh:
 		n.saveState()
+
+		// Calculate new quorum for new increased cluster size and send it out.
+		if event.Event == memberlist.NodeJoin {
+			newQuorum := math.Ceil(float64((len(n.memberlist.Members()) / 2) + 1))
+			n.sendNewQuorumToAll(int(newQuorum))
+		}
 
 	case <-n.shutdownCh:
 		n.toShutdown()

--- a/go.mod
+++ b/go.mod
@@ -4,5 +4,5 @@ go 1.14
 
 require (
 	github.com/hashicorp/logutils v1.0.0
-	github.com/hashicorp/memberlist v0.1.7
+	github.com/hashicorp/memberlist v0.2.2
 )

--- a/go.sum
+++ b/go.sum
@@ -20,8 +20,8 @@ github.com/hashicorp/golang-lru v0.5.0 h1:CL2msUPvZTLb5O648aiLNJw3hnBxN2+1Jq8rCO
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
-github.com/hashicorp/memberlist v0.1.7 h1:5WLszGdi8FjebYTCKuX9zaGNl7pD31uv6Bj6657HxqQ=
-github.com/hashicorp/memberlist v0.1.7/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
+github.com/hashicorp/memberlist v0.2.2 h1:5+RffWKwqJ71YPu9mWsF7ZOscZmwfasdA8kbdC7AO2g=
+github.com/hashicorp/memberlist v0.2.2/go.mod h1:MS2lj3INKhZjWNqd3N0m3J+Jxf3DAOnAH9VT3Sh9MUE=
 github.com/miekg/dns v1.1.26 h1:gPxPSwALAeHJSjarOs00QjVdV9QoBvc1D2ujQUr5BzU=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=

--- a/handlers.go
+++ b/handlers.go
@@ -188,13 +188,13 @@ func (n *Node) handleVoteResponse(msg VoteResponse) {
 	}
 }
 
-// handleNewQuorum handles the receivel of a new quorum message from a voluntarily leaving node.
-func (n *Node) handleNewQuorum(msg NewQuorum) {
-	n.logger.Printf("[DEBUG] raftify: Setting the quorum from %v to %v\n", n.quorum, msg.NewQuorum)
+// handleIntentionalNodeEvent handles the receival of an intentional node event broadcast from an
+// intentionally joining or leaving node.
+func (n *Node) handleIntentionalLeave(msg IntentionalLeave) {
+	n.logger.Printf("[DEBUG] raftify: Received quorum update on intentional leave (%v => %v)\n", n.quorum, msg.NewQuorum)
 	n.quorum = msg.NewQuorum
 
-	// Equal to 2, because this check is called just before the second to last node leaves.
-	if len(n.memberlist.Members()) == 2 {
+	if msg.NewQuorum == 1 {
 		n.logger.Printf("[DEBUG] raftify: %v is the only node left in the cluster, entering leader state for term %v...", n.config.ID, n.currentTerm)
 
 		// Switch to leader without calling toLeader in order to bypass the state change restriction

--- a/node.go
+++ b/node.go
@@ -246,8 +246,13 @@ func (n *Node) quorumReached(votes int) bool {
 	// a network partition, the quorum of the previous cluster size needs to be reached and thus
 	// no two leaders can exist simultaneously in both partitions. The larger partition will have
 	// a leader, the smaller one won't.
+	// If the node is the only node remaining, it can't fulfil the requirement of also reaching
+	// the previous quorum. In this case, the previous quorum is skipped. This is the only time
+	// this requirement is lifted.
 	n.logger.Printf("[DEBUG] raftify: %v quorum reached: (%v/%v)\n", n.state.toString(), votes, n.quorum)
-	n.quorum = int(len(n.memberlist.Members())/2) + 1
+	if n.quorum != 1 {
+		n.quorum = int(len(n.memberlist.Members())/2) + 1
+	}
 	return true
 }
 

--- a/node.go
+++ b/node.go
@@ -102,7 +102,7 @@ func (n *Node) createMemberlist() error {
 	// skipping it so the main loop can be started afterwards. All further join and
 	// leave events are caught in the main loop after this first occurrence.
 	go func() {
-		_ = <-n.events.eventCh
+		<-n.events.eventCh
 	}()
 
 	var err error
@@ -206,7 +206,7 @@ func initNode(logger *log.Logger, workingDir string) (*Node, error) {
 	// Also, block if the node is trying to rejoin an existing cluster as that will intentionally
 	// skip the bootstrap phase.
 	if node.config.Expect != 1 || node.rejoin {
-		_ = <-node.bootstrapCh
+		<-node.bootstrapCh
 	}
 	return node, nil
 }

--- a/node.go
+++ b/node.go
@@ -161,6 +161,9 @@ func initNode(logger *log.Logger, workingDir string) (*Node, error) {
 		missedPrevoteCycles: 0,
 	}
 
+	// Print out version information on initialization.
+	node.logger.Printf("[INFO] raftify: Running Raftify %v...", Version)
+
 	// If there is a state.json, it means that the node has not explicitly left the cluster
 	// and therefore must have been partitioned out or crashed/timed out. At this point, it
 	// is no longer guaranteed its memberlist is up-to-date and it therefore needs to initiate

--- a/types.go
+++ b/types.go
@@ -86,6 +86,11 @@ const (
 	// A vote response message is sent by the node who received the vote
 	// request to the candidate it originated from.
 	VoteResponseMsg
+
+	// A new quorum message is sent by a voluntarily leaving node. It triggers
+	// an immediate quorum change instead of having to wait for the cluster to
+	// detect and kick the dead node eventually.
+	NewQuorumMsg
 )
 
 // toString returns the string representation of a message type.
@@ -103,6 +108,8 @@ func (t *MessageType) toString() string {
 		return "VoteRequestMsg"
 	case VoteResponseMsg:
 		return "VoteResponseMsg"
+	case NewQuorumMsg:
+		return "NewQuorumMsg"
 	default:
 		return "unknown"
 	}

--- a/types.go
+++ b/types.go
@@ -87,10 +87,10 @@ const (
 	// request to the candidate it originated from.
 	VoteResponseMsg
 
-	// A new quorum message is sent by a voluntarily leaving node. It triggers
-	// an immediate quorum change instead of having to wait for the cluster to
-	// detect and kick the dead node eventually.
-	NewQuorumMsg
+	// An intentional leave message is broadcasted by a node leaving on its
+	// own accord. This does not include unintended crash- or timeout-related
+	// leave events.
+	IntentionalLeaveMsg
 )
 
 // toString returns the string representation of a message type.
@@ -108,8 +108,8 @@ func (t *MessageType) toString() string {
 		return "VoteRequestMsg"
 	case VoteResponseMsg:
 		return "VoteResponseMsg"
-	case NewQuorumMsg:
-		return "NewQuorumMsg"
+	case IntentionalLeaveMsg:
+		return "IntentionalLeaveMsg"
 	default:
 		return "unknown"
 	}

--- a/types_test.go
+++ b/types_test.go
@@ -83,9 +83,9 @@ func TestMessageTypeToString(t *testing.T) {
 		t.Fail()
 	}
 
-	msg = NewQuorumMsg
-	if msg.toString() != "NewQuorumMsg" {
-		t.Logf("Expected to get \"NewQuorumMsg\", instead got %v", msg.toString())
+	msg = IntentionalLeaveMsg
+	if msg.toString() != "IntentionalLeaveMsg" {
+		t.Logf("Expected to get \"IntentionalLeaveMsg\", instead got %v", msg.toString())
 		t.Fail()
 	}
 

--- a/types_test.go
+++ b/types_test.go
@@ -83,6 +83,12 @@ func TestMessageTypeToString(t *testing.T) {
 		t.Fail()
 	}
 
+	msg = NewQuorumMsg
+	if msg.toString() != "NewQuorumMsg" {
+		t.Logf("Expected to get \"NewQuorumMsg\", instead got %v", msg.toString())
+		t.Fail()
+	}
+
 	msg = 100
 	if msg.toString() != "unknown" {
 		t.Logf("Expected to get \"unknown\", instead got %v", msg.toString())

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package raftify
 
 const (
 	// Version is the main version number that is being run at the moment.
-	Version = "v0.2.0-RC1"
+	Version = "v0.2.0-RC2"
 )

--- a/version.go
+++ b/version.go
@@ -1,0 +1,6 @@
+package raftify
+
+const (
+	// Version is the main version number that is being run at the moment.
+	Version = "v0.2.0-RC1"
+)


### PR DESCRIPTION
Raftify is now able to distinguish between intended and crash- or timeout-related leave events. This allows it to immediately adjust the quorum for intended leave events instead of having to wait for the dead nodes to be kicked out of the cluster.