### PR TITLE
Bugfix prevote quorum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bugfixes
 
 * Fixed a bug that prevented nodes with `expect = 1` from becoming the cluster leader if there were other peers listed in the peerlist of the raftify.json file.
+* Fixed a bug that prevented the prevote quorum from being adjusted to the new cluster size.
 
 ### General Changes
 

--- a/handlers.go
+++ b/handlers.go
@@ -6,6 +6,9 @@ import (
 
 // handleHeartbeat handles the receival of a heartbeat message from a leader.
 func (n *Node) handleHeartbeat(msg Heartbeat) {
+	// Adjust quorum in any case
+	n.quorum = msg.Quorum
+
 	switch n.state {
 	case Follower:
 		if n.currentTerm < msg.Term {

--- a/messages.go
+++ b/messages.go
@@ -16,6 +16,7 @@ type Message struct {
 // Heartbeat defines the message sent out by the leader to all cluster members.
 type Heartbeat struct {
 	Term        uint64 `json:"term"`
+	Quorum      int    `json:"quorum"`
 	HeartbeatID uint64 `json:"heartbeat_id"`
 	LeaderID    string `json:"leader_id"`
 }
@@ -63,6 +64,7 @@ func (n *Node) sendHeartbeatToAll() {
 	hb := Heartbeat{
 		HeartbeatID: n.heartbeatIDList.currentHeartbeatID,
 		Term:        n.currentTerm,
+		Quorum:      n.quorum,
 		LeaderID:    n.config.ID,
 	}
 

--- a/precandidate.go
+++ b/precandidate.go
@@ -79,7 +79,6 @@ func (n *Node) runPreCandidate() {
 
 		// If only a minorty keeps prevoting and the precandidate quorum cannot be
 		// reached, increment the counter of missed prevote cycles.
-		n.logger.Printf("[DEBUG] raftify: Couldn't reach precandidate quorum: not enough prevotes (%v/%v)", n.preVoteList.received, n.quorum)
 		n.preVoteList.missedPrevoteCycles++
 
 		// If the precandidate hasn't reached the prevote quorum too many cycles in a row


### PR DESCRIPTION
There was a bug that only the leader node would adjust its quorum and not tell any of the other nodes, causing the quorum check to fail for clusters larger than 3. This PR fixes this issue.